### PR TITLE
Hack job to fix your coverage setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,10 @@
 [run]
-source = hupper, tests
+branch = true
+source =
+    hupper
+    tests
+parallel = true
+
+[report]
+show_missing = true
+precision = 2

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,10 @@ basepython =
     pypy: pypy
     py2: python2.7
     py3: python3.5
-
+usedevelop = true
 commands =
     pip install hupper[testing]
     py.test {posargs:}
-
-setenv =
-    COVERAGE_FILE=.coverage.{envname}
 
 [testenv:coverage]
 basepython = python3.5


### PR DESCRIPTION
Get coverage filtering to actually work. Key part is `usedevelop=true`.

Note that COVERAGE_FILE should not be customized. Just use `--cov-append`.

PS. Tested to work with `tox -e py35 -- --cov`

PPS. This is a hack job as the package ain't properly tested anymore (develop mode). Ideally you would fix your layout. Read more about it [here](http://blog.ionelmc.ro/2014/05/25/python-packaging/) and [here](https://hynek.me/articles/testing-packaging/).