### PR TITLE
Restore PyPy3 compatibility.

### DIFF
--- a/src/hupper/compat.py
+++ b/src/hupper/compat.py
@@ -23,22 +23,19 @@ except ImportError:
 
 
 try:
-    import importlib.util as imputil
+    from importlib.util import (
+        cache_from_source as get_pyc_path,
+        source_from_cache as get_py_path)
 except ImportError:
-    imputil = None
 
-if imputil:
-    get_pyc_path = imputil.cache_from_source
-    get_py_path = imputil.source_from_cache
-
-elif PY2:
-    get_pyc_path = lambda path: path + 'c'
-    get_py_path = lambda path: path[:-1]
+    if PY2:
+        get_pyc_path = lambda path: path + 'c'
+        get_py_path = lambda path: path[:-1]
 
 # fallback on python < 3.5
-else:
-    get_pyc_path = imp.cache_from_source
-    get_py_path = imp.source_from_cache
+    else:
+        get_pyc_path = imp.cache_from_source
+        get_py_path = imp.source_from_cache
 
 
 def is_watchdog_supported():

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ basepython =
     pypy: pypy
     py2: python2.7
     py3: python3.5
+    pypy3: pypy3
 
 commands =
     pip install hupper[testing]


### PR DESCRIPTION
Works at least on PyPy 5.5.0.

pypy3 left disabled on Travis becuase it is too old.