### PR TITLE
rewrite workers to be loaded using subprocess

### DIFF
--- a/src/hupper/compat.py
+++ b/src/hupper/compat.py
@@ -38,6 +38,12 @@ except ImportError:
         get_py_path = imp.source_from_cache
 
 
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+
 def is_watchdog_supported():
     """ Return ``True`` if watchdog is available."""
     try:

--- a/src/hupper/ipc.py
+++ b/src/hupper/ipc.py
@@ -98,8 +98,8 @@ def Pipe():
     c2pr_fd, c2pw_fd = os.pipe()
     p2cr_fd, p2cw_fd = os.pipe()
 
-    c1 = Connection(c2pr_fd, p2cw_fd, p2cr_fd, c2pw_fd)
-    c2 = Connection(p2cr_fd, c2pw_fd, c2pr_fd, p2cw_fd)
+    c1 = Connection(c2pr_fd, p2cw_fd)
+    c2 = Connection(p2cr_fd, c2pw_fd)
     return c1, c2
 
 class Connection(object):
@@ -107,30 +107,21 @@ class Connection(object):
     A connection to a bi-directional pipe.
 
     """
-    def __init__(self, r_fd, w_fd, remote_r_fd, remote_w_fd):
+    def __init__(self, r_fd, w_fd):
         self.r_fd = r_fd
         self.w_fd = w_fd
-        self.remote_r_fd = remote_r_fd
-        self.remote_w_fd = remote_w_fd
 
     def __getstate__(self):
         return {
             'r_handle': get_handle(self.r_fd),
             'w_handle': get_handle(self.w_fd),
-            'remote_r_handle': get_handle(self.remote_r_fd),
-            'remote_w_handle': get_handle(self.remote_w_fd),
         }
 
     def __setstate__(self, state):
         self.r_fd = open_handle(state['r_handle'], 'rb')
         self.w_fd = open_handle(state['w_handle'], 'wb')
-        self.remote_r_fd = open_handle(state['remote_r_handle'], 'rb')
-        self.remote_w_fd = open_handle(state['remote_w_handle'], 'wb')
 
     def activate(self):
-        close_fd(self.remote_r_fd, raises=False)
-        close_fd(self.remote_w_fd, raises=False)
-
         self.r = os.fdopen(self.r_fd, 'rb')
         self.w = os.fdopen(self.w_fd, 'wb')
 

--- a/src/hupper/ipc.py
+++ b/src/hupper/ipc.py
@@ -203,7 +203,9 @@ def set_inheritable(fd, inheritable):
             os.set_inheritable(fd, inheritable)
 
     elif WIN:
-        pass
+        h = get_handle(fd)
+        flags = winapi.HANDLE_FLAG_INHERIT if inheritable else 0
+        winapi.SetHandleInformation(h, winapi.HANDLE_FLAG_INHERIT, flags)
 
     else:
         flags = fcntl.fcntl(fd, fcntl.F_GETFD)

--- a/src/hupper/ipc.py
+++ b/src/hupper/ipc.py
@@ -299,9 +299,6 @@ def spawn_main(pipe_handle):
 
     prepare(preparation_data)
 
-    modname, funcname = spec.rsplit('.', 1)
-    module = importlib.import_module(modname)
-    func = getattr(module, funcname)
-
+    func = resolve_spec(spec)
     func(**kwargs)
     sys.exit(0)

--- a/src/hupper/ipc.py
+++ b/src/hupper/ipc.py
@@ -1,9 +1,21 @@
+import io
+import importlib
 import os
+import struct
 import sys
+import subprocess
 import threading
-import time
 
 from .compat import WIN
+from .compat import pickle
+from .compat import queue
+
+
+def resolve_spec(spec):
+    modname, funcname = spec.rsplit('.', 1)
+    module = importlib.import_module(modname)
+    func = getattr(module, funcname)
+    return func
 
 
 if WIN:  # pragma: no cover
@@ -38,55 +50,16 @@ if WIN:  # pragma: no cover
                 else:
                     raise
 
-    class StdinPipe(object):
-        _bufsize = 256
+    def snapshot_termios(fd):
+        pass
 
-        def __init__(self):
-            self._thread = None
-            self._local_fd = sys.stdin.fileno()
-            self.fd, self._write_fd = os.pipe()
-            set_inheritable(self.fd)
+    def restore_termios(fd, state):
+        pass
 
-        def start(self):
-            self._running = True
-            self._thread = threading.Thread(target=self._run)
-            self._thread.start()
+    def get_handle(fd):
+        return msvcrt.get_osfhandle(fd)
 
-        def _run(self):
-            while self._running:
-                if msvcrt.kbhit():
-                    ch = os.read(self._local_fd, self._bufsize)
-                    os.write(self._write_fd, ch)
-                time.sleep(0.05)
-
-        def stop(self):
-            self._running = False
-            self._thread.join()
-            self._thread = None
-
-            close_fd(self._write_fd, raises=False)
-            self._write_fd = None
-
-            close_fd(self.fd, raises=False)
-            self.fd = None
-
-        def snapshot_termios(self):
-            pass
-
-        def restore_termios(self):
-            pass
-
-    def send_fd(fd, pipe, pid):
-        hf = msvcrt.get_osfhandle(fd)
-        hp = winapi.OpenProcess(winapi.PROCESS_ALL_ACCESS, False, pid)
-        tp = winapi.DuplicateHandle(
-            winapi.GetCurrentProcess(), hf, hp,
-            0, False, winapi.DUPLICATE_SAME_ACCESS,
-        ).Detach()  # do not close the handle
-        pipe.send(tp)
-
-    def recv_fd(pipe, mode):
-        handle = pipe.recv()
+    def open_handle(handle, mode):
         flags = 0
         if 'w' not in mode and '+' not in mode:
             flags |= os.O_RDONLY
@@ -94,17 +67,7 @@ if WIN:  # pragma: no cover
             flags |= os.O_TEXT
         if 'a' in mode:
             flags |= os.O_APPEND
-        fd = msvcrt.open_osfhandle(handle, flags)
-        return fd
-
-    def patch_stdin(fd):
-        sys.stdin = os.fdopen(fd, 'r')
-
-    def snapshot_termios(fd):
-        pass
-
-    def restore_termios(fd, state):
-        pass
+        return msvcrt.open_osfhandle(handle, flags)
 
 else:
     import termios
@@ -113,40 +76,6 @@ else:
         def add_child(self, pid):
             # nothing to do on *nix
             pass
-
-    class StdinPipe(object):
-        def __init__(self):
-            self._local_fd = sys.stdin.fileno()
-            self._orig_termios = None
-            self.fd = os.dup(self._local_fd)
-            set_inheritable(self.fd)
-
-        def start(self):
-            pass
-
-        def stop(self):
-            close_fd(self.fd, raises=False)
-            self.fd = None
-
-        def snapshot_termios(self):
-            self._orig_termios = snapshot_termios(self._local_fd)
-
-        def restore_termios(self):
-            restore_termios(self._local_fd, self._orig_termios)
-
-    def send_fd(fd, pipe, pid):
-        pipe.send(fd)
-
-    def recv_fd(pipe, mode):
-        return pipe.recv()
-
-    def patch_stdin(fd):
-        # Python's input() function used by pdb and other things only uses
-        # readline if stdin matches the stdin file descriptor that the
-        # process started with (0). Since multiprocessing closes it already
-        # we can just dup the new fd over it.
-        os.dup2(fd, 0)
-        sys.stdin = os.fdopen(0, 'r')
 
     def snapshot_termios(fd):
         if os.isatty(fd):
@@ -158,11 +87,141 @@ else:
             termios.tcflush(fd, termios.TCIOFLUSH)
             termios.tcsetattr(fd, termios.TCSANOW, state)
 
+    def get_handle(fd):
+        return fd
+
+    def open_handle(handle, mode):
+        return handle
+
+
+class Pipe(object):
+    """
+    A pickle-able bidirectional pipe.
+
+    """
+    def __init__(self):
+        self.is_parent = True
+        self.parent_pid = os.getpid()
+        self.c2pr_fd, self.c2pw_fd = os.pipe()
+        self.p2cr_fd, self.p2cw_fd = os.pipe()
+
+        self.inheritable_fds = [self.c2pw_fd, self.p2cr_fd]
+
+    def __getstate__(self):
+        return dict(
+            parent_pid=self.parent_pid,
+            p2cr_handle=get_handle(self.p2cr_fd),
+            p2cw_handle=get_handle(self.p2cw_fd),
+            c2pr_handle=get_handle(self.c2pr_fd),
+            c2pw_handle=get_handle(self.c2pw_fd),
+        )
+
+    def __setstate__(self, state):
+        self.parent_pid = state['parent_pid']
+        self.is_parent = os.getpid() == self.parent_pid
+        if self.is_parent:
+            raise RuntimeError('pipe pickled to the same process')
+
+        self.p2cr_fd = open_handle(state['p2cr_handle'], 'rb')
+        self.p2cw_fd = open_handle(state['p2cw_handle'], 'wb')
+        self.c2pr_fd = open_handle(state['c2pr_handle'], 'rb')
+        self.c2pw_fd = open_handle(state['c2pw_handle'], 'wb')
+
+    def activate(self):
+        if self.is_parent:
+            close_fd(self.c2pw_fd, raises=False)
+            close_fd(self.p2cr_fd, raises=False)
+
+            self.c2pr = os.fdopen(self.c2pr_fd, 'rb')
+            self.p2cw = os.fdopen(self.p2cw_fd, 'wb')
+            self._send_packet = self._send_to_child
+            self._recv_packet = self._recv_from_child
+
+        else:
+            close_fd(self.c2pr_fd, raises=False)
+            close_fd(self.p2cw_fd, raises=False)
+
+            self.p2cr = os.fdopen(self.p2cr_fd, 'rb')
+            self.c2pw = os.fdopen(self.c2pw_fd, 'wb')
+            self._send_packet = self._send_to_parent
+            self._recv_packet = self._recv_from_parent
+
+        self.send_lock = threading.Lock()
+        self.reader_queue = queue.Queue()
+
+        self.reader_thread = threading.Thread(target=self._read_loop)
+        self.reader_thread.daemon = True
+        self.reader_thread.start()
+
+    def close(self):
+        if self.is_parent:
+            self.c2pr.close()
+            self.p2cw.close()
+
+        else:
+            self.c2pw.close()
+            self.p2cr.close()
+
+    def _send_to_parent(self, value):
+        return self._send_into(self.c2pw, value)
+
+    def _send_to_child(self, value):
+        return self._send_into(self.p2cw, value)
+
+    def _recv_from_parent(self, timeout=None):
+        return self._recv_from(self.p2cr, timeout=timeout)
+
+    def _recv_from_child(self, timeout=None):
+        return self._recv_from(self.c2pr, timeout=timeout)
+
+    def _send_into(self, fp, value):
+        data = pickle.dumps(value)
+        with self.send_lock:
+            fp.write(struct.pack('Q', len(data)))
+            fp.write(data)
+            fp.flush()
+        return len(data) + 8
+
+    def _recv_from(self, fp, timeout=None):
+        buf = io.BytesIO()
+        chunk = fp.read(8)
+        if not chunk:
+            return
+        size = remaining = struct.unpack('Q', chunk)[0]
+        while remaining > 0:
+            chunk = fp.read(remaining)
+            n = len(chunk)
+            if n == 0:
+                if remaining == size:
+                    raise EOFError
+                else:
+                    raise IOError('got end of file during message')
+            buf.write(chunk)
+            remaining -= n
+        return pickle.loads(buf.getvalue())
+
+    def _read_loop(self):
+        try:
+            while True:
+                packet = self._recv_packet()
+                if packet is None:
+                    break
+                self.reader_queue.put(packet)
+        except EOFError:
+            pass
+        self.reader_queue.put(None)
+
+    def send(self, value):
+        return self._send_packet(value)
+
+    def recv(self, timeout=None):
+        packet = self.reader_queue.get(block=True, timeout=timeout)
+        return packet
+
 
 def set_inheritable(fd):
     # py34 and above sets CLOEXEC automatically on file descriptors
-    # NOTE: this isn't usually an issue because multiprocessing doesn't
-    # actually exec on linux/macos, but we're depending on the behavior
+    # and we want to prevent that from happening
     if hasattr(os, 'get_inheritable') and not os.get_inheritable(fd):
         os.set_inheritable(fd, True)
 
@@ -174,3 +233,86 @@ def close_fd(fd, raises=True):
         except Exception:  # pragma: nocover
             if raises:
                 raise
+
+
+def args_from_interpreter_flags():
+    """
+    Return a list of command-line arguments reproducing the current
+    settings in sys.flags and sys.warnoptions.
+
+    """
+    flag_opt_map = {
+        'debug': 'd',
+        'dont_write_bytecode': 'B',
+        'no_user_site': 's',
+        'no_site': 'S',
+        'ignore_environment': 'E',
+        'verbose': 'v',
+        'bytes_warning': 'b',
+        'quiet': 'q',
+        'optimize': 'O',
+    }
+    args = []
+    for flag, opt in flag_opt_map.items():
+        v = getattr(sys.flags, flag, 0)
+        if v > 0:
+            args.append('-' + opt * v)
+    for opt in sys.warnoptions:
+        args.append('-W' + opt)
+    return args
+
+
+def get_command_line(**kwds):
+    prog = 'from hupper.ipc import spawn_main; spawn_main(%s)'
+    prog %= ', '.join('%s=%r' % item for item in kwds.items())
+    opts = args_from_interpreter_flags()
+    return [sys.executable] + opts + ['-c', prog]
+
+
+def get_preparation_data():
+    data = {}
+    data['sys.argv'] = sys.argv
+    return data
+
+
+def prepare(data):
+    if 'sys.argv' in data:
+        sys.argv = data['sys.argv']
+
+
+def spawn(spec, kwargs, pass_fds=()):
+    """
+    Invoke a python function in a subprocess.
+
+    """
+    r, w = os.pipe()
+    for fd in [r] + list(pass_fds):
+        set_inheritable(fd)
+
+    preparation_data = get_preparation_data()
+
+    r_handle = get_handle(r)
+    args = get_command_line(pipe_handle=r_handle)
+    process = subprocess.Popen(args, close_fds=False)
+
+    to_child = os.fdopen(w, 'wb')
+    to_child.write(pickle.dumps([preparation_data, spec, kwargs]))
+    to_child.close()
+
+    return process
+
+
+def spawn_main(pipe_handle):
+    fd = open_handle(pipe_handle, 'rb')
+    from_parent = os.fdopen(fd, 'rb')
+    preparation_data, spec, kwargs = pickle.load(from_parent)
+    from_parent.close()
+
+    prepare(preparation_data)
+
+    modname, funcname = spec.rsplit('.', 1)
+    module = importlib.import_module(modname)
+    func = getattr(module, funcname)
+
+    func(**kwargs)
+    sys.exit(0)

--- a/src/hupper/reloader.py
+++ b/src/hupper/reloader.py
@@ -6,10 +6,8 @@ import sys
 import threading
 import time
 
-from .compat import (
-    is_watchdog_supported,
-    queue,
-)
+from .compat import is_watchdog_supported
+from .compat import queue
 from .ipc import ProcessGroup
 from .worker import (
     Worker,
@@ -152,21 +150,18 @@ class Reloader(object):
 
             while not self.monitor.is_changed() and self.worker.is_alive():
                 try:
-                    # if the child has sent any data then restart
-                    if self.worker.pipe.poll(0):
-                        # do not read, the pipe is closed after the break
-                        break
-                except EOFError:  # pragma: nocover
-                    pass
-
-                try:
-                    path = self.worker.files_queue.get(
-                        timeout=self.reload_interval,
-                    )
+                    cmd = self.worker.pipe.recv(timeout=self.reload_interval)
                 except queue.Empty:
-                    pass
+                    continue
+
+                if not cmd or cmd[0] == 'reload':
+                    break
+
+                if cmd[0] == 'watch':
+                    self.monitor.add_path(cmd[1])
+
                 else:
-                    self.monitor.add_path(path)
+                    raise RuntimeError('received unknown command')
 
         except KeyboardInterrupt:
             if self.worker.is_alive():

--- a/src/hupper/reloader.py
+++ b/src/hupper/reloader.py
@@ -158,7 +158,8 @@ class Reloader(object):
                     break
 
                 if cmd[0] == 'watch':
-                    self.monitor.add_path(cmd[1])
+                    for path in cmd[1]:
+                        self.monitor.add_path(path)
 
                 else:
                     raise RuntimeError('received unknown command')

--- a/src/hupper/winapi.py
+++ b/src/hupper/winapi.py
@@ -47,6 +47,9 @@ PROCESS_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0xFFF
 
 DUPLICATE_SAME_ACCESS = 0x0002
 
+HANDLE_FLAG_INHERIT = 0x0001
+HANDLE_FLAG_PROTECT_FROM_CLOSE = 0x0002
+
 
 class IO_COUNTERS(ctypes.Structure):
     _fields_ = [
@@ -156,3 +159,8 @@ def SetInformationJobObject(hJob, infoType, jobObjectInfo):
 def AssignProcessToJobObject(hJob, hProcess):
     ret = kernel32.AssignProcessToJobObject(hJob, hProcess)
     CheckError(ret, 'failed to assign process to job object')
+
+
+def SetHandleInformation(h, dwMask, dwFlags):
+    ret = kernel32.SetHandleInformation(h, dwMask, dwFlags)
+    CheckError(ret, 'failed to set handle information')

--- a/src/hupper/worker.py
+++ b/src/hupper/worker.py
@@ -103,7 +103,7 @@ class Worker(object):
         self.worker_spec = spec
         self.worker_args = args
         self.worker_kwargs = kwargs
-        self.pipe = ipc.Pipe()
+        self.pipe, self._child_pipe = ipc.Pipe()
         self.terminated = False
         self.pid = None
         self.process = None
@@ -117,12 +117,12 @@ class Worker(object):
             spec=self.worker_spec,
             spec_args=self.worker_args,
             spec_kwargs=self.worker_kwargs,
-            pipe=self.pipe,
+            pipe=self._child_pipe,
         )
         self.process = ipc.spawn(
             'hupper.worker.worker_main',
             kwargs=kw,
-            pass_fds=self.pipe.inheritable_fds,
+            pass_fds=[self._child_pipe.r_fd, self._child_pipe.w_fd],
         )
         self.pid = self.process.pid
 

--- a/src/hupper/worker.py
+++ b/src/hupper/worker.py
@@ -128,6 +128,7 @@ class Worker(object):
 
         # activate the pipe after forking
         self.pipe.activate()
+        self._child_pipe.close()
 
     def is_alive(self):
         if self.process:

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -8,8 +8,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_myapp_reloads_when_touching_ini(testapp):
     testapp.start('myapp', ['--reload'])
-    testapp.wait_for_response(interval=1)
-    time.sleep(1)
+    testapp.wait_for_response()
+    time.sleep(2)
     util.touch(os.path.join(here, 'myapp/foo.ini'))
     testapp.wait_for_response()
     testapp.stop()
@@ -20,8 +20,8 @@ def test_myapp_reloads_when_touching_ini(testapp):
 
 def test_myapp_reloads_when_touching_pyfile(testapp):
     testapp.start('myapp', ['--reload'])
-    testapp.wait_for_response(interval=1)
-    time.sleep(1)
+    testapp.wait_for_response()
+    time.sleep(2)
     util.touch(os.path.join(here, 'myapp/cli.py'))
     testapp.wait_for_response()
     testapp.stop()

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -15,7 +15,6 @@ def test_myapp_reloads_when_touching_ini(testapp):
     testapp.stop()
 
     assert len(testapp.response) == 2
-    assert testapp.stderr == ''
     assert testapp.stdout != ''
 
 
@@ -28,5 +27,4 @@ def test_myapp_reloads_when_touching_pyfile(testapp):
     testapp.stop()
 
     assert len(testapp.response) == 2
-    assert testapp.stderr == ''
     assert testapp.stdout != ''


### PR DESCRIPTION
- Workers now spawn in a subprocess to avoid a shared process space between the monitor and the app.

- Added a new pipe implementation that can be pickled to a subprocess for simpler handling of communication.

- Manually set file descriptors to non-inheritable on Python < 3.4.

Fixes #17 