### PR TITLE
allow overriding the default monitor via env var

### DIFF
--- a/src/hupper/__init__.py
+++ b/src/hupper/__init__.py
@@ -1,7 +1,7 @@
 # public api
 # flake8: noqa
 
-from .compat import is_watchdog_supported
+from .utils import is_watchdog_supported
 
 from .reloader import (
     start_reloader,

--- a/src/hupper/compat.py
+++ b/src/hupper/compat.py
@@ -39,15 +39,6 @@ except ImportError:
     import pickle
 
 
-def is_watchdog_supported():
-    """ Return ``True`` if watchdog is available."""
-    try:
-        import watchdog
-    except ImportError:
-        return False
-    return True
-
-
 ################################################
 # cross-compatible metaclass implementation
 # Copyright (c) 2010-2012 Benjamin Peterson

--- a/src/hupper/interfaces.py
+++ b/src/hupper/interfaces.py
@@ -14,7 +14,7 @@ class IReloaderProxy(with_metaclass(abc.ABCMeta)):
 
 
 class IFileMonitorFactory(with_metaclass(abc.ABCMeta)):
-    def __call__(self, callback):
+    def __call__(self, callback, **kw):
         """ Return an :class:`.IFileMonitor` instance.
 
         ``callback`` is a callable to be invoked by the ``IFileMonitor``

--- a/src/hupper/ipc.py
+++ b/src/hupper/ipc.py
@@ -1,6 +1,5 @@
 import io
 import imp
-import importlib
 import os
 import struct
 import sys
@@ -10,13 +9,7 @@ import threading
 from .compat import WIN
 from .compat import pickle
 from .compat import queue
-
-
-def resolve_spec(spec):
-    modname, funcname = spec.rsplit('.', 1)
-    module = importlib.import_module(modname)
-    func = getattr(module, funcname)
-    return func
+from .utils import resolve_spec
 
 
 if WIN:  # pragma: no cover

--- a/src/hupper/polling.py
+++ b/src/hupper/polling.py
@@ -16,10 +16,10 @@ class PollingFileMonitor(threading.Thread, IFileMonitor):
     disk. Do not set this too low or it will eat your CPU and kill your drive.
 
     """
-    def __init__(self, callback, poll_interval=1):
+    def __init__(self, callback, interval=1, **kw):
         super(PollingFileMonitor, self).__init__()
         self.callback = callback
-        self.poll_interval = poll_interval
+        self.poll_interval = interval
         self.paths = set()
         self.mtimes = {}
         self.lock = threading.Lock()

--- a/src/hupper/utils.py
+++ b/src/hupper/utils.py
@@ -1,0 +1,17 @@
+import importlib
+
+
+def resolve_spec(spec):
+    modname, funcname = spec.rsplit('.', 1)
+    module = importlib.import_module(modname)
+    func = getattr(module, funcname)
+    return func
+
+
+def is_watchdog_supported():
+    """ Return ``True`` if watchdog is available."""
+    try:
+        import watchdog  # noqa: F401
+    except ImportError:
+        return False
+    return True

--- a/src/hupper/watchdog.py
+++ b/src/hupper/watchdog.py
@@ -17,7 +17,7 @@ class WatchdogFileMonitor(FileSystemEventHandler, Observer, IFileMonitor):
     ``callback`` is a callable that accepts a path to a changed file.
 
     """
-    def __init__(self, callback):
+    def __init__(self, callback, **kw):
         super(WatchdogFileMonitor, self).__init__()
         self.callback = callback
         self.paths = set()

--- a/tests/test_reloader.py
+++ b/tests/test_reloader.py
@@ -2,15 +2,17 @@ import os
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-def make_proxy(*args, **kwargs):
+def make_proxy(monitor_factory):
     from hupper.reloader import FileMonitorProxy
-    return FileMonitorProxy(*args, **kwargs)
+    proxy = FileMonitorProxy()
+    proxy.monitor = monitor_factory(proxy.file_changed)
+    return proxy
 
 def test_proxy_proxies():
     class DummyMonitor(object):
         started = stopped = joined = False
 
-        def __call__(self, cb):
+        def __call__(self, cb, **kw):
             self.cb = cb
             return self
 
@@ -34,7 +36,7 @@ def test_proxy_proxies():
 
 def test_proxy_expands_paths(tmpdir):
     class DummyMonitor(object):
-        def __call__(self, cb):
+        def __call__(self, cb, **kw):
             self.cb = cb
             self.paths = []
             return self
@@ -59,7 +61,7 @@ def test_proxy_expands_paths(tmpdir):
 
 def test_proxy_tracks_changes(capsys):
     class DummyMonitor(object):
-        def __call__(self, cb):
+        def __call__(self, cb, **kw):
             self.cb = cb
             return self
 


### PR DESCRIPTION
An alternative would be to support setuptools entry points to make this slightly safer than loading arbitrary python code from an environment variable. How much of a concern is this? I wanted to avoid statically defining 'watchdog' and 'poll' as hard-coded strings so I left it as a dotted python path. Entry points would be the flexible way to avoid hard coding strings.