### PR TITLE
only track source files

### DIFF
--- a/src/hupper/compat.py
+++ b/src/hupper/compat.py
@@ -19,17 +19,14 @@ except ImportError:
 
 try:
     from importlib.util import (
-        cache_from_source as get_pyc_path,
         source_from_cache as get_py_path,
     )
 except ImportError:
     if PY2:
-        get_pyc_path = lambda path: path + 'c'
         get_py_path = lambda path: path[:-1]
 
     # fallback on python < 3.5
     else:
-        get_pyc_path = imp.cache_from_source
         get_py_path = imp.source_from_cache
 
 

--- a/src/hupper/reloader.py
+++ b/src/hupper/reloader.py
@@ -164,7 +164,7 @@ class Reloader(object):
                     for path in cmd[1]:
                         self.monitor.add_path(path)
 
-                else:
+                else:  # pragma: no cover
                     raise RuntimeError('received unknown command')
 
         except KeyboardInterrupt:

--- a/src/hupper/watchdog.py
+++ b/src/hupper/watchdog.py
@@ -40,8 +40,21 @@ class WatchdogFileMonitor(FileSystemEventHandler, Observer, IFileMonitor):
             if path not in self.paths:
                 self.paths.add(path)
 
-    def on_any_event(self, event):
+    def _check(self, path):
         with self.lock:
-            path = event.src_path
             if path in self.paths:
                 self.callback(path)
+
+    def on_created(self, event):
+        self._check(event.src_path)
+
+    def on_modified(self, event):
+        self._check(event.src_path)
+
+    def on_moved(self, event):
+        self._check(event.src_path)
+        self._check(event.dest_path)
+        self.add_path(event.dest_path)
+
+    def on_deleted(self, event):
+        self._check(event.src_path)

--- a/src/hupper/worker.py
+++ b/src/hupper/worker.py
@@ -5,10 +5,11 @@ import threading
 import time
 import traceback
 
+from . import ipc
 from .compat import get_py_path
 from .compat import interrupt_main
 from .interfaces import IReloaderProxy
-from . import ipc
+from .utils import resolve_spec
 
 
 class WatchSysModules(threading.Thread):
@@ -224,7 +225,7 @@ def worker_main(spec, pipe, spec_args=None, spec_kwargs=None):
     poller.start()
 
     # import the worker path before polling sys.modules
-    func = ipc.resolve_spec(spec)
+    func = resolve_spec(spec)
 
     # start the worker
     try:

--- a/src/hupper/worker.py
+++ b/src/hupper/worker.py
@@ -79,7 +79,7 @@ def iter_module_paths(modules=None):
     for module in modules:
         try:
             filename = module.__file__
-        except (AttributeError, ImportError):  # pragma: nocover
+        except (AttributeError, ImportError):  # pragma: no cover
             continue
         if filename is not None:
             abs_filename = os.path.abspath(filename)
@@ -96,7 +96,7 @@ class WatchForParentShutdown(threading.Thread):
     def run(self):
         try:
             # wait until the pipe breaks
-            while self.pipe.recv():  # pragma: nocover
+            while self.pipe.recv():  # pragma: no cover
                 pass
         except EOFError:
             pass
@@ -159,7 +159,7 @@ class Worker(object):
         if self.pipe:
             try:
                 self.pipe.close()
-            except:  # pragma: nocover
+            except Exception:  # pragma: no cover
                 pass
             finally:
                 self.pipe = None
@@ -235,13 +235,13 @@ def worker_main(spec, pipe, spec_args=None, spec_kwargs=None):
     # start the worker
     try:
         func(*spec_args, **spec_kwargs)
-    except:
+    except BaseException:  # catch any error
         try:
             # attempt to send imported paths to the master prior to crashing
             poller.update_paths()
             poller.search_traceback(sys.exc_info()[2])
             poller.stop()
             poller.join()
-        except:  # pragma: no cover
+        except Exception:  # pragma: no cover
             pass
         raise


### PR DESCRIPTION
This changes hupper to ignore pyc/pyo files by default if an equivalent source file can be found. If not, the compiled file will continue to be tracked instead.

fixes https://github.com/Pylons/pyramid/issues/3149