### PR TITLE
pass a logger around so we can stop using print statements everywhere

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+unreleased
+==========
+
+- The ``hupper.watchdog.WatchdogFileMonitor`` will now output some info
+  when it receives ulimit or other errors from ``watchdog``.
+  See https://github.com/Pylons/hupper/pull/33
+
+- Allow ``-q`` and ``-v`` cli options to control verbosity.
+  See https://github.com/Pylons/hupper/pull/33
+
+- Pass a ``logger`` value to the ``hupper.interfaces.IFileMonitorFactory``.
+  This is an instance of ``hupper.interfaces.ILogger`` and can be used by
+  file monitors to output errors and debug information.
+  See https://github.com/Pylons/hupper/pull/33
+
 1.2 (2018-05-01)
 ================
 

--- a/src/hupper/cli.py
+++ b/src/hupper/cli.py
@@ -2,6 +2,7 @@ import argparse
 import runpy
 import sys
 
+from .logger import LogLevel
 from .reloader import start_reloader
 
 
@@ -9,10 +10,24 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", dest="module", required=True)
     parser.add_argument("-w", dest="watch", action="append")
+    parser.add_argument("-v", dest="verbose", action='store_true')
+    parser.add_argument("-q", dest="quiet", action='store_true')
 
     args, unknown_args = parser.parse_known_args()
 
-    reloader = start_reloader("hupper.cli.main")
+    if args.quiet:
+        level = LogLevel.ERROR
+
+    elif args.verbose:
+        level = LogLevel.DEBUG
+
+    else:
+        level = LogLevel.INFO
+
+    reloader = start_reloader(
+        "hupper.cli.main",
+        verbose=level,
+    )
 
     sys.argv[1:] = unknown_args
     sys.path.insert(0, "")

--- a/src/hupper/interfaces.py
+++ b/src/hupper/interfaces.py
@@ -21,6 +21,14 @@ class IFileMonitorFactory(with_metaclass(abc.ABCMeta)):
         when file changes are detected. It should accept the path of
         the changed file as its only parameter.
 
+        Extra keyword-only arguments:
+
+        ``interval`` is the value of ``reload_interval`` passed to the
+        reloader and may be used to control behavior in the file monitor.
+
+        ``logger`` is an :class:`.ILogger` instance used to record runtime
+        output.
+
         """
 
 
@@ -44,3 +52,17 @@ class IFileMonitor(with_metaclass(abc.ABCMeta)):
     @abc.abstractmethod
     def join(self):
         """ Block until the monitor has stopped."""
+
+
+class ILogger(with_metaclass(abc.ABCMeta)):
+    @abc.abstractmethod
+    def error(self, msg):
+        """ Record an error message."""
+
+    @abc.abstractmethod
+    def info(self, msg):
+        """ Record an informational message."""
+
+    @abc.abstractmethod
+    def debug(self, msg):
+        """ Record a debug-only message."""

--- a/src/hupper/logger.py
+++ b/src/hupper/logger.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+
+import sys
+
+from .interfaces import ILogger
+
+
+class LogLevel:
+    ERROR = 0
+    INFO = 1
+    DEBUG = 2
+
+
+class DefaultLogger(ILogger):
+    def __init__(self, level):
+        self.level = level
+
+    def _out(self, level, msg):
+        if level <= self.level:
+            print(msg, file=sys.stderr)
+
+    def error(self, msg):
+        self._out(LogLevel.ERROR, msg)
+
+    def info(self, msg):
+        self._out(LogLevel.INFO, msg)
+
+    def debug(self, msg):
+        self._out(LogLevel.DEBUG, msg)

--- a/src/hupper/watchdog.py
+++ b/src/hupper/watchdog.py
@@ -16,10 +16,13 @@ class WatchdogFileMonitor(FileSystemEventHandler, Observer, IFileMonitor):
 
     ``callback`` is a callable that accepts a path to a changed file.
 
+    ``logger`` is an :class:`hupper.interfaces.ILogger` instance.
+
     """
-    def __init__(self, callback, **kw):
+    def __init__(self, callback, logger, **kw):
         super(WatchdogFileMonitor, self).__init__()
         self.callback = callback
+        self.logger = logger
         self.paths = set()
         self.dirpaths = set()
         self.lock = threading.Lock()
@@ -30,10 +33,10 @@ class WatchdogFileMonitor(FileSystemEventHandler, Observer, IFileMonitor):
             if dirpath not in self.dirpaths:
                 try:
                     self.schedule(self, dirpath)
-                except (OSError, IOError):  # pragma: no cover
-                    # ideally we would handle this better but if the
-                    # directory is missing watchdog raises an error
-                    pass
+                except (OSError, IOError) as ex:  # pragma: no cover
+                    # watchdog raises exceptions if folders are missing
+                    # or if the ulimit is passed
+                    self.logger.error('watchdog error: ' + str(ex))
                 else:
                     self.dirpaths.add(dirpath)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,3 +35,28 @@ def testapp(request):
             app.name, app.args, app.exitcode))
         err('-- stdout --\n%s' % app.stdout)
         err('-- stderr --\n%s' % app.stderr)
+
+class DummyLogger:
+    def __init__(self):
+        self.messages = []
+
+    def reset(self):
+        self.messages = []
+
+    def get_output(self, *levels):
+        if not levels:
+            levels = {'info', 'error', 'debug'}
+        return '\n'.join(msg for lvl, msg in self.messages if lvl in levels)
+
+    def info(self, msg):
+        self.messages.append(('info', msg))
+
+    def error(self, msg):
+        self.messages.append(('error', msg))
+
+    def debug(self, msg):
+        self.messages.append(('debug', msg))
+
+@pytest.fixture
+def logger():
+    return DummyLogger()

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -15,7 +15,7 @@ def test_myapp_reloads_when_touching_ini(testapp):
     testapp.stop()
 
     assert len(testapp.response) == 2
-    assert testapp.stdout != ''
+    assert testapp.stderr != ''
 
 
 def test_myapp_reloads_when_touching_pyfile(testapp):
@@ -27,4 +27,4 @@ def test_myapp_reloads_when_touching_pyfile(testapp):
     testapp.stop()
 
     assert len(testapp.response) == 2
-    assert testapp.stdout != ''
+    assert testapp.stderr != ''


### PR DESCRIPTION
this allows us to pass a logger around everywhere so that file monitors can output errors and we can avoid using print statements... this is an internal-only change and so should not affect bw-compat at all with the monitors.