### PR TITLE
do not crash when receiving corrupted json from watchman

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+- Ignore corrupted packets coming from watchman that occur in semi-random
+  scenarios. See https://github.com/Pylons/hupper/pull/38
+
 1.3 (2018-05-21)
 ================
 

--- a/src/hupper/watchman.py
+++ b/src/hupper/watchman.py
@@ -132,7 +132,11 @@ class WatchmanFileMonitor(threading.Thread, IFileMonitor):
         line = self._readline()
         if not PY2:
             line = line.decode('utf8')
-        return json.loads(line)
+        try:
+            return json.loads(line)
+        except Exception:  # pragma: no cover
+            self.logger.info('ignoring corrupted payload from watchman')
+            return {}
 
     def _send(self, msg):
         cmd = json.dumps(msg)


### PR DESCRIPTION
I do not know why, but in practice while using watchman I infrequently receive corrupted json payloads. I think it's related to interactions with other watchers on the system (such as from other node.js file loaders using watchman) and it causes watchman to dump corrupted json onto the socket. This fix will just skip such packets and keep running.