### PR TITLE
ignore changes in installed packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,12 @@
 unreleased
 ==========
 
-- Ignore changes to any installed files. This includes mostly changes to any
-  files in the stdlib and ``site-packages``.
+- Ignore changes to any system / installed files. This includes mostly
+  changes to any files in the stdlib and ``site-packages``. Anything that is
+  installed in editable mode or not installed at all will still be monitored.
+  This drastically reduces the number of files that ``hupper`` needs to
+  monitor.
+  See https://github.com/Pylons/hupper/pull/40
 
 1.3.1 (2018-10-05)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+- Ignore changes to any installed files. This includes mostly changes to any
+  files in the stdlib and ``site-packages``.
+
 1.3.1 (2018-10-05)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,8 @@ show-source = True
 max-line-length = 80
 
 ignore =
-    E722
+    # W504: line break after binary operator
+    W504,
 
 [check-manifest]
 ignore =

--- a/src/hupper/compat.py
+++ b/src/hupper/compat.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 import imp
 import importlib
+import site
 import sys
 
 PY2 = sys.version_info[0] == 2
@@ -32,6 +33,26 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle
+
+
+def get_site_packages():  # pragma: no cover
+    try:
+        paths = site.getsitepackages()
+        if site.ENABLE_USER_SITE:
+            paths.append(site.getusersitepackages())
+        return paths
+
+    # virtualenv does not ship with a getsitepackages impl so we fallback
+    # to using distutils if we can
+    # https://github.com/pypa/virtualenv/issues/355
+    except Exception:
+        try:
+            from distutils.sysconfig import get_python_lib
+            return [get_python_lib()]
+
+        # just incase, don't fail here, it's not worth it
+        except Exception:
+            return []
 
 
 ################################################

--- a/src/hupper/worker.py
+++ b/src/hupper/worker.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import sys
+import sysconfig
 import threading
 import time
 import traceback
@@ -8,6 +9,7 @@ import traceback
 from . import ipc
 from .compat import get_py_path
 from .compat import interrupt_main
+from .compat import get_site_packages
 from .interfaces import IReloaderProxy
 from .utils import resolve_spec
 
@@ -16,12 +18,14 @@ class WatchSysModules(threading.Thread):
     """ Poll ``sys.modules`` for imported modules."""
     poll_interval = 1
 
-    def __init__(self, callback):
+    def __init__(self, callback, ignore_installed_packages=True):
         super(WatchSysModules, self).__init__()
         self.paths = set()
         self.callback = callback
         self.lock = threading.Lock()
         self.stopped = False
+        self.ignore_installed_packages = ignore_installed_packages
+        self.installed_packages = get_installed_packages()
 
     def run(self):
         while not self.stopped:
@@ -40,7 +44,7 @@ class WatchSysModules(threading.Thread):
                     self.paths.add(path)
                     new_paths.append(path)
         if new_paths:
-            self.callback(new_paths)
+            self.watch_paths(new_paths)
 
     def search_traceback(self, tb):
         """ Inspect a traceback for new paths to add to our path set."""
@@ -52,7 +56,29 @@ class WatchSysModules(threading.Thread):
                     self.paths.add(path)
                     new_paths.append(path)
         if new_paths:
-            self.callback(new_paths)
+            self.watch_paths(new_paths)
+
+    def watch_paths(self, paths):
+        if self.ignore_installed_packages:
+            paths = [
+                path for path in paths
+                if not self.in_installed_packages(path)
+            ]
+        if paths:
+            self.callback(paths)
+
+    def in_installed_packages(self, path):
+        for prefix in self.installed_packages:
+            if path.startswith(prefix):
+                return True
+        return False
+
+
+def get_installed_packages():
+    paths = get_site_packages()
+    for path in sysconfig.get_paths().values():
+        paths.append(path)
+    return paths
 
 
 def expand_source_paths(paths):


### PR DESCRIPTION
this includes stdlib and site-packages

my feeling is that there's no reason to support an opt-out here, we should just ignore these files which will greatly reduce the number of files being watched by default, maybe I'd allow some sort of `HUPPER_IGNORE_INSTALLED_PACKAGES=no` env var if people felt strongly about it or a flag passed at runtime, but then any library integrating hupper (like pserve) would need a way to expose it