### PR TITLE
Fix SyntaxError in documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,9 +41,11 @@ path in string format. For example, ``myapp.scripts.serve.main``.
     import hupper
     import waitress
 
+
     def wsgi_app(environ, start_response):
-        start_response('200 OK', [('Content-Type', 'text/plain'])
-        yield [b'hello']
+        start_response('200 OK', [('Content-Type', 'text/plain')])
+        yield b'hello'
+
 
     def main(args=sys.argv[1:]):
         if '--reload' in args:


### PR DESCRIPTION
Plus make the code work.

Previously there was an exception in
```
  File ".../waitress/task.py", in write
    towrite += data + b'\r\n'
TypeError: can only concatenate list (not "str") to list
```