### PR TITLE
Support recursive glob in Python >= 3.5

### DIFF
--- a/src/hupper/compat.py
+++ b/src/hupper/compat.py
@@ -37,10 +37,13 @@ except ImportError:
     import pickle
 
 
-if PY2 or sys.version_info[1]<5:
+if PY2 or sys.version_info[1] < 5:
+    from glob import glob as gg
+
     def glob(pathname, recursive=False):
-        from glob import glob as gg
         return gg(pathname)
+
+
 else:
     from glob import glob
 

--- a/src/hupper/compat.py
+++ b/src/hupper/compat.py
@@ -37,6 +37,14 @@ except ImportError:
     import pickle
 
 
+if PY2 or sys.version_info[1]<5:
+    def glob(pathname, recursive=False):
+        from glob import glob as gg
+        return gg(pathname)
+else:
+    from glob import glob
+
+
 def get_site_packages():  # pragma: no cover
     try:
         paths = site.getsitepackages()

--- a/src/hupper/reloader.py
+++ b/src/hupper/reloader.py
@@ -5,9 +5,8 @@ import signal
 import sys
 import threading
 import time
-from glob import glob
 
-from .compat import queue
+from .compat import queue, glob
 from .ipc import ProcessGroup
 from .logger import DefaultLogger
 from .utils import default
@@ -39,7 +38,7 @@ class FileMonitorProxy(object):
         # if the glob does not match any files then go ahead and pass
         # the pattern to the monitor anyway incase it is just a file that
         # is currently missing
-        for p in glob(path) or [path]:
+        for p in glob(path, recursive=True) or [path]:
             if not any(x.match(p) for x in self.ignore_files):
                 self.monitor.add_path(p)
 


### PR DESCRIPTION
Make "**" pattern recursive in Python >= 3.5
According to Python's documentation:

> If recursive is true, the pattern “**” will match any files and zero or more directories and subdirectories.

Default value of recursive is False.