### PR TITLE
support pressing enter to trigger a reload after a crash

### DIFF
--- a/src/hupper/logger.py
+++ b/src/hupper/logger.py
@@ -27,3 +27,14 @@ class DefaultLogger(ILogger):
 
     def debug(self, msg):
         self._out(LogLevel.DEBUG, msg)
+
+
+class SilentLogger(ILogger):
+    def error(self, msg):
+        pass
+
+    def info(self, msg):
+        pass
+
+    def debug(self, msg):
+        pass

--- a/src/hupper/worker.py
+++ b/src/hupper/worker.py
@@ -149,7 +149,7 @@ class Worker(object):
             pipe=self._child_pipe,
         )
         self.process = ipc.spawn(
-            'hupper.worker.worker_main',
+            __name__ + '.worker_main',
             kwargs=kw,
             pass_fds=[self._child_pipe.r_fd, self._child_pipe.w_fd],
         )


### PR DESCRIPTION
- add a `wait_main` which is invoked in a subprocess after the main worker dies
- if ENTER is pressed during the `wait_main` then trigger a reload
- this also makes the pausing logic more clear after the worker dies
- skip the reload_interval after a `reloader.trigger_reload()` invocation from the worker