### PR TITLE
SIGINT was being squashed in wait_for_changes after a crash

### DIFF
--- a/src/hupper/worker.py
+++ b/src/hupper/worker.py
@@ -146,6 +146,7 @@ class Worker(object):
         # responsible for it
         self._child_pipe.close()
 
+    @property
     def is_alive(self):
         if self.exitcode is not None:
             return False


### PR DESCRIPTION
Also the process wasn't dying immediately when receiving a SIGINT - waiting the default shutdown_interval to exit out.