### PR TITLE
Forward exitcode after signals like SIGINT

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+unreleased
+==========
+
+- When the reloader is stopped, exit with the same code received from the
+  subprocess.
+  See https://github.com/Pylons/hupper/pull/81
+
 1.11 (2022-01-02)
 =================
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -110,3 +110,4 @@ Contributors
 - Jens Carl (2017-05-22)
 - Eric Atkin (2019-02-15)
 - Yeray Díaz Díaz (2019-10-03)
+- Marcel Jackwerth (2023-03-23)

--- a/src/hupper/reloader.py
+++ b/src/hupper/reloader.py
@@ -137,13 +137,11 @@ class Reloader(object):
         the process didn't handle the interrupt gracefully.
 
         """
-        exitcode = 1
+        exitcode = -1
         with self._setup_runtime():
             while True:
-                result, worker_exitcode = self._run_worker()
+                result, exitcode = self._run_worker()
                 if result == WorkerResult.EXIT:
-                    if worker_exitcode is not None:
-                        exitcode = worker_exitcode
                     break
                 start = time.time()
                 if result == WorkerResult.WAIT:


### PR DESCRIPTION
HTTP servers tend to support graceful shutdown and will return
an exitcode of 0 when sending a signal like SIGINT.

This change will make `hupper` return that exitcode instead of
always exiting with 1.

Should fix #80 if the IDE does not break on `SystemExit(0)`.

### Test Plan

- Ran `hupper --shutdown-interval 5 -m http.server`
- Hit `Ctrl+C`
- Observed exitcode of 0